### PR TITLE
chore: release v0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jcape/iso10383"
 rust-version = "1.85.0"
-version = "0.1.1"
+version = "0.1.2"
 
 [profile.release]
 lto = true

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/jcape/iso10383/compare/v0.1.1...v0.1.2) - 2025-06-11
+
+### Fixed
+
+- *(lint)* fix parser changelog lint.
+
+### Other
+
+- *(test)* add june 2025 file to parser tests
+
 ## [0.1.1](https://github.com/jcape/iso10383/compare/v0.1.0...v0.1.1) - 2025-06-05
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `iso10383-parser`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/jcape/iso10383/compare/v0.1.1...v0.1.2) - 2025-06-11

### Fixed

- *(lint)* fix parser changelog lint.

### Other

- *(test)* add june 2025 file to parser tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).