### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ members = ["parser", "types"]
 
 [workspace.dependencies]
 chrono = { version = "0.4", default-features = false }
-iso10383-parser = { path = "./parser", version = "0.1.2" }
+iso10383-parser = { path = "./parser", version = "0.2.0" }
 iso10383-static = { path = "./static", version = "0.1.2" }
-iso10383-types = { path = "./types", version = "0.1.2" }
+iso10383-types = { path = "./types", version = "0.2.0" }
 iso17442-types = { version = "0.2", default-features = false }
 quick-xml = { version = "0.38.3", features = ["serialize"] }
 
@@ -31,7 +31,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jcape/iso10383"
 rust-version = "1.87.0"
-version = "0.1.2"
+version = "0.2.0"
 
 [profile.release]
 lto = true

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/jcape/iso10383/compare/iso10383-parser-v0.1.2...iso10383-parser-v0.2.0) - 2025-09-01
+
+### Added
+
+- august list
+- [**breaking**] `types` crate with &mic/Mic, parser enums
+
+### Fixed
+
+- fix issues with iso10383-types release
+
+### Other
+
+- add missing enum docs, fix some style issues
+
 ## [0.1.2](https://github.com/jcape/iso10383/compare/v0.1.1...v0.1.2) - 2025-06-11
 
 ### Fixed

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,3 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0](https://github.com/jcape/iso10383/compare/iso10383-types-v0.1.2...iso10383-types-v0.2.0) - 2025-09-01
+
+### Added
+
+- [**breaking**] `types` crate with &mic/Mic, parser enums
+
+### Fixed
+
+- fix issues with iso10383-types release
+
+### Other
+
+- add types changelog


### PR DESCRIPTION



## 🤖 New release

* `iso10383-types`: 0.1.2 -> 0.2.0
* `iso10383-parser`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `iso10383-parser` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_missing.ron

Failed in:
  enum iso10383_parser::Category, previously in file /tmp/.tmprJC35c/iso10383-parser/src/lib.rs:24
  enum iso10383_parser::Kind, previously in file /tmp/.tmprJC35c/iso10383-parser/src/lib.rs:13
  enum iso10383_parser::Status, previously in file /tmp/.tmprJC35c/iso10383-parser/src/lib.rs:76

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct iso10383_parser::Mic, previously in file /tmp/.tmprJC35c/iso10383-parser/src/lib.rs:126
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `iso10383-types`

<blockquote>

## [0.2.0](https://github.com/jcape/iso10383/compare/iso10383-types-v0.1.2...iso10383-types-v0.2.0) - 2025-09-01

### Added

- [**breaking**] `types` crate with &mic/Mic, parser enums

### Fixed

- fix issues with iso10383-types release

### Other

- add types changelog
</blockquote>

## `iso10383-parser`

<blockquote>

## [0.2.0](https://github.com/jcape/iso10383/compare/iso10383-parser-v0.1.2...iso10383-parser-v0.2.0) - 2025-09-01

### Added

- august list
- [**breaking**] `types` crate with &mic/Mic, parser enums

### Fixed

- fix issues with iso10383-types release

### Other

- add missing enum docs, fix some style issues
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).