### PR TITLE
chore: release v0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ exclude = [".cache"]
 [workspace.dependencies]
 chrono = { version = "0.4.20", default-features = false }
 iso3166-static = { version = "0.4.0", default-features = false }
-iso10383-macros = { version = "=0.4.1", path = "./macros" }
-iso10383-parser = { version = "=0.4.1", path = "./parser" }
-iso10383-static = { version = "=0.4.1", path = "./static" }
-iso10383-types = { version = "=0.4.1", path = "./types" }
+iso10383-macros = { version = "=0.4.2", path = "./macros" }
+iso10383-parser = { version = "=0.4.2", path = "./parser" }
+iso10383-static = { version = "=0.4.2", path = "./static" }
+iso10383-types = { version = "=0.4.2", path = "./types" }
 iso17442-types = { version = "0.3", default-features = false }
 quick-xml = { version = "0.39.0", features = ["serialize"] }
 serde = { version = "1", default-features = false }
@@ -69,7 +69,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jcape/iso10383"
 rust-version = "1.88.0"
-version = "0.4.1"
+version = "0.4.2"
 
 [profile.release]
 lto = true

--- a/macros/README.md
+++ b/macros/README.md
@@ -11,7 +11,7 @@ As an end-user, this probably isn't the crate you're looking for, you probably w
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/iso10383-macros.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/iso10383-macros/0.4.1
+[crate-link]: https://crates.io/crates/iso10383-macros/0.4.2
 [docs-image]: https://img.shields.io/docsrs/iso10383-macros?style=for-the-badge
-[docs-link]: https://docs.rs/crate/iso10383-macros/0.4.1/iso10383_macros
-[msrv-image]: https://img.shields.io/crates/msrv/iso10383-macros/0.4.1?style=for-the-badge
+[docs-link]: https://docs.rs/crate/iso10383-macros/0.4.2/iso10383_macros
+[msrv-image]: https://img.shields.io/crates/msrv/iso10383-macros/0.4.2?style=for-the-badge

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 [dependencies]
 chrono = { workspace = true, features = ["std", "serde"] }
 iso3166-static = { workspace = true, features = ["serde", "alloc"] }
-iso10383-types = { version = "=0.4.1", path = "../types", features = ["serde"] }
+iso10383-types = { version = "=0.4.2", path = "../types", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/parser/README.md
+++ b/parser/README.md
@@ -11,7 +11,7 @@ As an end-user, this probably isn't the crate you're looking for, you probably w
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/iso10383-parser.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/iso10383-parser/0.4.1
+[crate-link]: https://crates.io/crates/iso10383-parser/0.4.2
 [docs-image]: https://img.shields.io/docsrs/iso10383-parser?style=for-the-badge
-[docs-link]: https://docs.rs/crate/iso10383-parser/0.4.1/iso10383_parser
-[msrv-image]: https://img.shields.io/crates/msrv/iso10383-parser/0.4.1?style=for-the-badge
+[docs-link]: https://docs.rs/crate/iso10383-parser/0.4.2/iso10383_parser
+[msrv-image]: https://img.shields.io/crates/msrv/iso10383-parser/0.4.2?style=for-the-badge

--- a/static/README.md
+++ b/static/README.md
@@ -32,7 +32,7 @@ assert_eq!(Code::Iexg, code);
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/iso10383-static.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/iso10383-static/0.4.1
-[docs-image]: https://img.shields.io/docsrs/iso10383-static/0.4.1?style=for-the-badge
-[docs-link]: https://docs.rs/crate/iso10383-static/0.4.1/iso10383_static/
-[msrv-image]: https://img.shields.io/crates/msrv/iso10383-static/0.4.1?style=for-the-badge
+[crate-link]: https://crates.io/crates/iso10383-static/0.4.2
+[docs-image]: https://img.shields.io/docsrs/iso10383-static/0.4.2?style=for-the-badge
+[docs-link]: https://docs.rs/crate/iso10383-static/0.4.2/iso10383_static/
+[msrv-image]: https://img.shields.io/crates/msrv/iso10383-static/0.4.2?style=for-the-badge

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/jcape/iso10383/compare/iso10383-types-v0.4.1...iso10383-types-v0.4.2) - 2026-02-06
+
+### Other
+
+- release v0.4.1
+
 ## [0.4.1](https://github.com/jcape/iso10383/compare/iso10383-types-v0.4.0...iso10383-types-v0.4.1) - 2026-02-05
 
 ### Other

--- a/types/README.md
+++ b/types/README.md
@@ -29,7 +29,7 @@ assert_eq!(SRC, mcode.as_str());
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/iso10383-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/iso10383-types/0.4.1
-[docs-image]: https://img.shields.io/docsrs/iso10383-types/0.4.1?style=for-the-badge
-[docs-link]: https://docs.rs/crate/iso10383-types/0.4.1/iso10383_types/
-[msrv-image]: https://img.shields.io/crates/msrv/iso10383-types/0.4.1?style=for-the-badge
+[crate-link]: https://crates.io/crates/iso10383-types/0.4.2
+[docs-image]: https://img.shields.io/docsrs/iso10383-types/0.4.2?style=for-the-badge
+[docs-link]: https://docs.rs/crate/iso10383-types/0.4.2/iso10383_types/
+[msrv-image]: https://img.shields.io/crates/msrv/iso10383-types/0.4.2?style=for-the-badge


### PR DESCRIPTION



## 🤖 New release

* `iso10383-types`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `iso10383-parser`: 0.4.1 -> 0.4.2
* `iso10383-macros`: 0.4.1 -> 0.4.2
* `iso10383-static`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `iso10383-types`

<blockquote>

## [0.4.2](https://github.com/jcape/iso10383/compare/iso10383-types-v0.4.1...iso10383-types-v0.4.2) - 2026-02-06

### Other

- release v0.4.1
</blockquote>

## `iso10383-parser`

<blockquote>

## [0.4.1](https://github.com/jcape/iso10383/compare/iso10383-parser-v0.4.0...iso10383-parser-v0.4.1) - 2026-02-05

### Other

- enhanced clippy
</blockquote>

## `iso10383-macros`

<blockquote>

## [0.4.1](https://github.com/jcape/iso10383/compare/iso10383-macros-v0.4.0...iso10383-macros-v0.4.1) - 2026-02-05

### Added

- Add the `Code::country()` accessor.

### Other

- enhanced clippy
</blockquote>

## `iso10383-static`

<blockquote>

## [0.4.1](https://github.com/jcape/iso10383/compare/iso10383-static-v0.4.0...iso10383-static-v0.4.1) - 2026-02-05

### Other

- enhanced clippy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).