### PR TITLE
chore: release v0.4.2

### DIFF
--- a/macros/CHANGELOG.md
+++ b/macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/jcape/iso10383/compare/iso10383-macros-v0.4.1...iso10383-macros-v0.4.2) - 2026-02-07
+
+### Other
+
+- release v0.4.2
+
 ## [0.4.1](https://github.com/jcape/iso10383/compare/iso10383-macros-v0.4.0...iso10383-macros-v0.4.1) - 2026-02-05
 
 ### Added

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/jcape/iso10383/compare/iso10383-parser-v0.4.1...iso10383-parser-v0.4.2) - 2026-02-07
+
+### Other
+
+- release v0.4.2
+
 ## [0.4.1](https://github.com/jcape/iso10383/compare/iso10383-parser-v0.4.0...iso10383-parser-v0.4.1) - 2026-02-05
 
 ### Other

--- a/static/CHANGELOG.md
+++ b/static/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/jcape/iso10383/compare/iso10383-static-v0.4.1...iso10383-static-v0.4.2) - 2026-02-07
+
+### Other
+
+- release v0.4.2
+
 ## [0.4.1](https://github.com/jcape/iso10383/compare/iso10383-static-v0.4.0...iso10383-static-v0.4.1) - 2026-02-05
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `iso10383-types`: 0.4.1 -> 0.4.2
* `iso10383-parser`: 0.4.1 -> 0.4.2
* `iso10383-macros`: 0.4.1 -> 0.4.2
* `iso10383-static`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `iso10383-types`

<blockquote>

## [0.4.2](https://github.com/jcape/iso10383/compare/iso10383-types-v0.4.1...iso10383-types-v0.4.2) - 2026-02-06

### Other

- release v0.4.1
</blockquote>

## `iso10383-parser`

<blockquote>

## [0.4.2](https://github.com/jcape/iso10383/compare/iso10383-parser-v0.4.1...iso10383-parser-v0.4.2) - 2026-02-07

### Other

- release v0.4.2
</blockquote>

## `iso10383-macros`

<blockquote>

## [0.4.2](https://github.com/jcape/iso10383/compare/iso10383-macros-v0.4.1...iso10383-macros-v0.4.2) - 2026-02-07

### Other

- release v0.4.2
</blockquote>

## `iso10383-static`

<blockquote>

## [0.4.2](https://github.com/jcape/iso10383/compare/iso10383-static-v0.4.1...iso10383-static-v0.4.2) - 2026-02-07

### Other

- release v0.4.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).