### PR TITLE
chore: release v0.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ exclude = [".cache"]
 [workspace.dependencies]
 chrono = { version = "0.4.20", default-features = false }
 iso3166-static = { version = "0.4.0", default-features = false }
-iso10383-macros = { version = "=0.4.2", path = "./macros" }
-iso10383-parser = { version = "=0.4.2", path = "./parser" }
-iso10383-static = { version = "=0.4.2", path = "./static" }
-iso10383-types = { version = "=0.4.2", path = "./types" }
+iso10383-macros = { version = "=0.4.3", path = "./macros" }
+iso10383-parser = { version = "=0.4.3", path = "./parser" }
+iso10383-static = { version = "=0.4.3", path = "./static" }
+iso10383-types = { version = "=0.4.3", path = "./types" }
 iso17442-types = { version = "0.3", default-features = false }
 quick-xml = { version = "0.39.0", features = ["serialize"] }
 serde = { version = "1", default-features = false }
@@ -69,7 +69,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jcape/iso10383"
 rust-version = "1.88.0"
-version = "0.4.2"
+version = "0.4.3"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ A collection of crates for use with ISO 18383 Market Identifier Codes.
 [parser-link]: https://github.com/jcape/iso10383/tree/main/parser
 [macros-link]: https://github.com/jcape/iso10383/tree/main/macros
 [types-crate-image]: https://img.shields.io/crates/v/iso10383-types.svg?style=flat-square
-[types-crate-link]: https://crates.io/crates/iso10383-types/0.4.2/
+[types-crate-link]: https://crates.io/crates/iso10383-types/0.4.3/
 [static-crate-image]: https://img.shields.io/crates/v/iso10383-static.svg?style=flat-square
-[static-crate-link]: https://crates.io/crates/iso10383-static/0.4.2/
+[static-crate-link]: https://crates.io/crates/iso10383-static/0.4.3/
 [parser-crate-image]: https://img.shields.io/crates/v/iso10383-parser.svg?style=flat-square
-[parser-crate-link]: https://crates.io/crates/iso10383-parser/0.4.2/
+[parser-crate-link]: https://crates.io/crates/iso10383-parser/0.4.3/
 [macros-crate-image]: https://img.shields.io/crates/v/iso10383-macros.svg?style=flat-square
-[macros-crate-link]: https://crates.io/crates/iso10383-macros/0.4.2/
+[macros-crate-link]: https://crates.io/crates/iso10383-macros/0.4.3/
 [license-image]: https://img.shields.io/github/license/jcape/iso10383?style=flat-square
 [license-link]: LICENSE
 [deps-image]: https://deps.rs/repo/github/jcape/iso10383/status.svg?style=flat-square

--- a/macros/README.md
+++ b/macros/README.md
@@ -11,7 +11,7 @@ As an end-user, this probably isn't the crate you're looking for, you probably w
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/iso10383-macros.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/iso10383-macros/0.4.2
+[crate-link]: https://crates.io/crates/iso10383-macros/0.4.3
 [docs-image]: https://img.shields.io/docsrs/iso10383-macros?style=for-the-badge
-[docs-link]: https://docs.rs/crate/iso10383-macros/0.4.2/iso10383_macros
-[msrv-image]: https://img.shields.io/crates/msrv/iso10383-macros/0.4.2?style=for-the-badge
+[docs-link]: https://docs.rs/crate/iso10383-macros/0.4.3/iso10383_macros
+[msrv-image]: https://img.shields.io/crates/msrv/iso10383-macros/0.4.3?style=for-the-badge

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/jcape/iso10383/compare/iso10383-parser-v0.4.2...iso10383-parser-v0.4.3) - 2026-02-10
+
+### Added
+
+- Add February 2026 data.
+
 ## [0.4.1](https://github.com/jcape/iso10383/compare/iso10383-parser-v0.4.0...iso10383-parser-v0.4.1) - 2026-02-05
 
 ### Other

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 [dependencies]
 chrono = { workspace = true, features = ["std", "serde"] }
 iso3166-static = { workspace = true, features = ["serde", "alloc"] }
-iso10383-types = { version = "=0.4.2", path = "../types", features = ["serde"] }
+iso10383-types = { version = "=0.4.3", path = "../types", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/parser/README.md
+++ b/parser/README.md
@@ -11,7 +11,7 @@ As an end-user, this probably isn't the crate you're looking for, you probably w
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/iso10383-parser.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/iso10383-parser/0.4.2
+[crate-link]: https://crates.io/crates/iso10383-parser/0.4.3
 [docs-image]: https://img.shields.io/docsrs/iso10383-parser?style=for-the-badge
-[docs-link]: https://docs.rs/crate/iso10383-parser/0.4.2/iso10383_parser
-[msrv-image]: https://img.shields.io/crates/msrv/iso10383-parser/0.4.2?style=for-the-badge
+[docs-link]: https://docs.rs/crate/iso10383-parser/0.4.3/iso10383_parser
+[msrv-image]: https://img.shields.io/crates/msrv/iso10383-parser/0.4.3?style=for-the-badge

--- a/static/CHANGELOG.md
+++ b/static/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/jcape/iso10383/compare/iso10383-static-v0.4.2...iso10383-static-v0.4.3) - 2026-02-10
+
+### Added
+
+- Add February 2026 data.
+
 ## [0.4.1](https://github.com/jcape/iso10383/compare/iso10383-static-v0.4.0...iso10383-static-v0.4.1) - 2026-02-05
 
 ### Other

--- a/static/README.md
+++ b/static/README.md
@@ -32,7 +32,7 @@ assert_eq!(Code::Iexg, code);
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/iso10383-static.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/iso10383-static/0.4.2
-[docs-image]: https://img.shields.io/docsrs/iso10383-static/0.4.2?style=for-the-badge
-[docs-link]: https://docs.rs/crate/iso10383-static/0.4.2/iso10383_static/
-[msrv-image]: https://img.shields.io/crates/msrv/iso10383-static/0.4.2?style=for-the-badge
+[crate-link]: https://crates.io/crates/iso10383-static/0.4.3
+[docs-image]: https://img.shields.io/docsrs/iso10383-static/0.4.3?style=for-the-badge
+[docs-link]: https://docs.rs/crate/iso10383-static/0.4.3/iso10383_static/
+[msrv-image]: https://img.shields.io/crates/msrv/iso10383-static/0.4.3?style=for-the-badge

--- a/types/README.md
+++ b/types/README.md
@@ -29,7 +29,7 @@ assert_eq!(SRC, mcode.as_str());
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/iso10383-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/iso10383-types/0.4.2
-[docs-image]: https://img.shields.io/docsrs/iso10383-types/0.4.2?style=for-the-badge
-[docs-link]: https://docs.rs/crate/iso10383-types/0.4.2/iso10383_types/
-[msrv-image]: https://img.shields.io/crates/msrv/iso10383-types/0.4.2?style=for-the-badge
+[crate-link]: https://crates.io/crates/iso10383-types/0.4.3
+[docs-image]: https://img.shields.io/docsrs/iso10383-types/0.4.3?style=for-the-badge
+[docs-link]: https://docs.rs/crate/iso10383-types/0.4.3/iso10383_types/
+[msrv-image]: https://img.shields.io/crates/msrv/iso10383-types/0.4.3?style=for-the-badge


### PR DESCRIPTION



## 🤖 New release

* `iso10383-types`: 0.4.2 -> 0.4.3
* `iso10383-parser`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `iso10383-macros`: 0.4.2 -> 0.4.3
* `iso10383-static`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `iso10383-types`

<blockquote>

## [0.4.2](https://github.com/jcape/iso10383/compare/iso10383-types-v0.4.1...iso10383-types-v0.4.2) - 2026-02-06

### Other

- release v0.4.1
</blockquote>

## `iso10383-parser`

<blockquote>

## [0.4.3](https://github.com/jcape/iso10383/compare/iso10383-parser-v0.4.2...iso10383-parser-v0.4.3) - 2026-02-10

### Added

- Add February 2026 data.
</blockquote>

## `iso10383-macros`

<blockquote>

## [0.4.1](https://github.com/jcape/iso10383/compare/iso10383-macros-v0.4.0...iso10383-macros-v0.4.1) - 2026-02-05

### Added

- Add the `Code::country()` accessor.

### Other

- enhanced clippy
</blockquote>

## `iso10383-static`

<blockquote>

## [0.4.3](https://github.com/jcape/iso10383/compare/iso10383-static-v0.4.2...iso10383-static-v0.4.3) - 2026-02-10

### Added

- Add February 2026 data.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).